### PR TITLE
Changing 'return_type' on 'CatalogItemsApiModel' and 'ListingsItemsApiModel' get methods

### DIFF
--- a/lib/catalog-items-api-model/api/catalog_api.rb
+++ b/lib/catalog-items-api-model/api/catalog_api.rb
@@ -70,7 +70,7 @@ module AmzSpApi::CatalogItemsApiModel
       # http body (model)
       post_body = opts[:body] 
 
-      return_type = opts[:return_type] || 'Item' 
+      return_type = opts[:return_type] || 'AmzSpApi::CatalogItemsApiModel::Item'
 
       auth_names = opts[:auth_names] || []
       data, status_code, headers = @api_client.call_api(:GET, local_var_path,

--- a/lib/listings-items-api-model/api/listings_api.rb
+++ b/lib/listings-items-api-model/api/listings_api.rb
@@ -146,7 +146,7 @@ module AmzSpApi::ListingsItemsApiModel
       # http body (model)
       post_body = opts[:body] 
 
-      return_type = opts[:return_type] || 'Item' 
+      return_type = opts[:return_type] || 'AmzSpApi::ListingsItemsApiModel::Item'
 
       auth_names = opts[:auth_names] || []
       data, status_code, headers = @api_client.call_api(:GET, local_var_path,


### PR DESCRIPTION
As mentioned on this [issue](https://github.com/ericcj/amz_sp_api/issues/41) on original repository, `get_listings_item` from `AmzSpApi::ListingsItemsApiModel` and `get_catalog_item` from `AmzSpApi::CatalogItemsApiModel` are sometimes returning wrong objects as response.

This is the code causing it: 
https://github.com/spocket-co/amz_sp_api/blob/84cd2dfc1398eee632da9b6f3ebfba25f591877a/lib/api_client.rb#L239

It lists some gem's constants and finds the first one that has a subclass named as the requested `return_type` - which is currently only `Item` for both APIs.

But as the order isn't controlled, if both APIs are required in the code, sometimes it returns the wrong subclass `Item` (e.g. Catalog API returns an ListingsItemApiModel, and vice-versa.


With this PR we are specifing the whole class name to prevent that problem.