### PR TITLE
Adding 'confirm_shipment' to orders shipment API

### DIFF
--- a/lib/orders-api-model/api/shipment_api.rb
+++ b/lib/orders-api-model/api/shipment_api.rb
@@ -78,5 +78,68 @@ module AmzSpApi::OrdersApiModel
       end
       return data, status_code, headers
     end
+
+    # Confirm shipment for an order that you specify.  **Usage Plan:**  | Rate (requests per second) | Burst | | ---- | ---- | | 2 | 10 |  The `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The table above indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values then those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](doc:usage-plans-and-rate-limits-in-the-sp-api).
+    # @param body The request body for the updateShipmentStatus operation.
+    # @param order_id An Amazon-defined order identifier, in 3-7-7 format.
+    # @param [Hash] opts the optional parameters
+    # @return [nil]
+    def confirm_shipment(body, order_id, opts = {})
+      confirm_shipment_with_http_info(body, order_id, opts)
+      nil
+    end
+
+    # Confirm shipment for an order that you specify.  **Usage Plan:**  | Rate (requests per second) | Burst | | ---- | ---- | | 2 | 10 |  The &#x60;x-amzn-RateLimit-Limit&#x60; response header returns the usage plan rate limits that were applied to the requested operation, when available. The table above indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values then those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](doc:usage-plans-and-rate-limits-in-the-sp-api).
+    # @param body The request body for the updateShipmentStatus operation.
+    # @param order_id An Amazon-defined order identifier, in 3-7-7 format.
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(nil, Integer, Hash)>] nil, response status code and response headers
+    def confirm_shipment_with_http_info(body, order_id, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: ShipmentApi.confirm_shipment ...'
+      end
+      # verify the required parameter 'body' is set
+      if @api_client.config.client_side_validation && body.nil?
+        fail ArgumentError, "Missing the required parameter 'body' when calling ShipmentApi.confirm_shipment"
+      end
+      # verify the required parameter 'order_id' is set
+      if @api_client.config.client_side_validation && order_id.nil?
+        fail ArgumentError, "Missing the required parameter 'order_id' when calling ShipmentApi.confirm_shipment"
+      end
+      # resource path
+      local_var_path = '/orders/v0/orders/{orderId}/shipmentConfirmation'.sub('{' + 'orderId' + '}', order_id.to_s)
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:body] || @api_client.object_to_http_body(body) 
+
+      return_type = opts[:return_type] 
+
+      auth_names = opts[:auth_names] || []
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type)
+
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: ShipmentApi#confirm_shipment\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end


### PR DESCRIPTION
In order to call [POST shipmentConfirmation](https://developer-docs.amazon.com/sp-api/docs/orders-api-v0-reference#post-ordersv0ordersorderidshipmentconfirmation), we need to implement its usage.

This PR adds `confirm_shipment` and `confirm_shipment_with_http_info` methods to `AmzSpApi::OrdersApiModel::ShipmentApi`.